### PR TITLE
feat(DataPointAreaChart): switch to mcs-lite-ui

### DIFF
--- a/client/app/components/deviceDetail/deviceDetail.css
+++ b/client/app/components/deviceDetail/deviceDetail.css
@@ -6,6 +6,9 @@
 }
 
 .graphPreview {
+  height: 200px;
+  width: 66%;
+  padding: 16px;
   background-color: #fff;
   margin: 20px 9px;
 }

--- a/client/app/components/deviceDetail/index.js
+++ b/client/app/components/deviceDetail/index.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import { DataPointAreaChart } from 'mcs-lite-ui';
+import moment from 'moment';
 
 import Footer from '../footer';
 import Header from '../header';
@@ -57,7 +59,32 @@ const DeviceDetail = ({ devices, editDevice, deleteDevice }) => {
         />
         <PanelHeader />
         <div className={styles.graphPreview}>
-          <Graph data={mockupGraphData}/>
+          <DataPointAreaChart
+            data={mockupGraphData}
+            isAnimationActive
+            XAxisProps={{
+              tickFormatter: value => moment(value).format('MM-DD HH:mm')
+            }}
+            tooltipProps={{
+              formatter: value => `資料點:${value}`,
+              labelFormatter: value => `時間：${moment(value).format('YYYY-MM-DD HH:mm')}`,
+            }}
+          />
+        </div>
+        
+        <div className={styles.graphPreview}>
+          <DataPointAreaChart
+            data={mockupGraphData}
+            type="step"
+            isAnimationActive
+            XAxisProps={{
+              tickFormatter: value => moment(value).format('MM-DD HH:mm')
+            }}
+            tooltipProps={{
+              formatter: value => `資料點:${value}`,
+              labelFormatter: value => `時間：${moment(value).format('YYYY-MM-DD HH:mm')}`,
+            }}
+          />
         </div>
       </div>
       <Footer />

--- a/client/package.json
+++ b/client/package.json
@@ -62,7 +62,7 @@
     "mcs-displaycard-integer": "0.0.2",
     "mcs-lite-icon": "^0.0.1",
     "mcs-lite-theme": "^0.0.1",
-    "mcs-lite-ui": "^0.0.1",
+    "mcs-lite-ui": "^0.1.0",
     "moment": "^2.17.1",
     "mtk-icon": "https://s3-ap-southeast-1.amazonaws.com/mtk.linkit/Mediatek-Cloud/mtk-icon/1.0.11.tgz",
     "mtk-ui": "https://s3-ap-southeast-1.amazonaws.com/mtk.linkit/Mediatek-Cloud/mtk-ui/2.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jsonschema": "^1.1.1",
     "jsonwebtoken": "^7.2.1",
     "lodash": "^4.17.4",
-    "mcs-lite-mobile-web": "^0.0.1",
+    "mcs-lite-mobile-web": "^0.1.0",
     "mocha": "^3.2.0",
     "nedb": "^1.8.0",
     "node-uuid": "^1.4.7",


### PR DESCRIPTION
- Bump `mcs-lite-*` versions ([Changelog](https://github.com/evenchange4/mcs-lite/blob/master/CHANGELOG.md))
- Replace `graph` component with mcs-lite-ui `DataPointAreaChart` component. ([Live demo](http://mcs-lite-ui.netlify.com/?selectedKind=DataPointAreaChart&selectedStory=With%20isAnimationActive%20props&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel))

## Screenshots

### for desktop
<img width="956" alt="2017-02-23 17 49 48" src="https://cloud.githubusercontent.com/assets/1527371/23254180/2054807c-f9f2-11e6-99c3-199f88a68951.png">

### for mobile
<img width="799" alt="2017-02-23 17 13 54" src="https://cloud.githubusercontent.com/assets/1527371/23254188/2c4b1ce2-f9f2-11e6-916d-9104cbee05dc.png">

