### PR TITLE
Revert "reset .babelrc" branch

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["latest", "react", "stage-0"],
+  "presets": ["mcs-lite"],
   "plugins": ["transform-decorators-legacy"]
 }


### PR DESCRIPTION
seems good with new version babel-preset-mcs-lite, revert this commit