### PR TITLE
feat(gzip): enable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@
 ```
 $ npm run test:watch
 ```
+
+## Gzip
+
+[Express compression middleware](https://github.com/expressjs/compression#expressconnect) is enabled by default. If you want to disable it, set `GZIP_DISABLE` to `true`.
+
+```
+$ NODE_ENV=prod GZIP_DISABLE='true' node server
+```

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "body-parser": "^1.15.2",
     "chai": "^3.5.0",
+    "compression": "^1.6.2",
     "connect-multiparty": "^2.0.0",
     "cookie-parser": "^1.4.3",
     "crypto": "0.0.3",

--- a/restserver/index.js
+++ b/restserver/index.js
@@ -16,6 +16,7 @@ var connectToDB = require('./libs/index').connectToDB;
 var dbConfig = require('../configs/db');
 var os = require('os');
 var StreamServer = require('node-rtsp-rtmp-server');
+var compression = require('compression')
 var socketPort = require('../configs/wot.json').port;
 
 var connectDB = connectToDB(dbConfig).init();
@@ -35,6 +36,17 @@ app.oauth = new OAuthServer({
 
 app.engine('html', require('ejs').renderFile);
 app.set('views', path.resolve(__dirname, '../client'));
+
+
+/**
+ * [Gzip] compress all responses
+ * https://github.com/expressjs/compression#expressconnect
+ *
+ * @author Michael Hsu
+ */
+if (process.env.GZIP_DISABLE !== 'true') {
+  app.use(compression())
+}
 
 app.use(function(req, res, next) {
   res.header("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
## Gzip

[Express compression middleware](https://github.com/expressjs/compression#expressconnect) is enabled by default. If you want to disable it, set `GZIP_DISABLE` to `true`.

```
$ NODE_ENV=prod GZIP_DISABLE='true' node server
```
